### PR TITLE
Include cookies in requests

### DIFF
--- a/Project/README.MD
+++ b/Project/README.MD
@@ -43,6 +43,8 @@ Yes, initially on application load, it will take some time to download the loade
 
 **Path** to the blob url (default "[appDataPath]\\blobs")
 
+**Cookies** adds cookies to the request made when getting the blobs in the format of: cookie1=cookieValue1;cookie2=cookieValue2
+
 ```
 <episerver.framework>
 	<blob defaultProvider="MissingFileBlobProvider">
@@ -52,6 +54,7 @@ Yes, initially on application load, it will take some time to download the loade
 				ProdUrl="http://www.gosso.se/"
 				UrlResolverUrl="modules/Gosso.EpiserverAddOn.DownloadIfMissingFileBlob/urlresolver.ashx"
 				RestrictedFileExt=".docx.doc.pdf.exe.zip.mov.mp4"
+				Cookies="cookie1=cookieValue1;cookie2=cookieValue2"
 				type="Gosso.EpiserverAddOn.DownloadIfMissingFileBlob.Provider, Gosso.EpiserverAddOn.DownloadIfMissingFileBlob" />
 		</providers>
 	</blob>


### PR DESCRIPTION
Hey! Lovin' the provider! 

However, in our current project the prod server (or rather our integrated dev environment) requires a certain cookie value for the request to be allowed; thus the normal implementation failed.

In this PR I added an extra config property called Cookies that can supply the httpClient with cookies to include.

I also moved the httpClient to a shared field, which should be a bit better performance wise as well.