### PR TITLE
UrlResolverUrl fix

### DIFF
--- a/Project/DownloadIfMissingFileProvider.cs
+++ b/Project/DownloadIfMissingFileProvider.cs
@@ -154,10 +154,10 @@ namespace Gosso.EPiServerAddOn.DownloadIfMissingFileBlob
 
             if (config.Get("UrlResolverUrl") != null)
             {
-                UrlResolverUrl = config.Get("UrlResolverUrl");
+                UrlResolverUrl = config.Get("UrlResolverUrl").ToLower();
             }
             else
-                UrlResolverUrl = DefaultUrl;
+                UrlResolverUrl = DefaultUrl.Replace("{UrlResolver}", "urlresolver.ashx").ToLower();
 
             if (Activated)
             {


### PR DESCRIPTION
We had some problem when we not defined the UrlResolverUrl in our webconfig, so I found that the defaultUrl was set to modules/Gosso.EPiServerAddOn.DownloadIfMissingFileBlob/{UrlResolver} and in commit https://github.com/LucGosso/Gosso.EPiServerAddOn.DownloadIfMissingFileBlob/commit/c2c1dac81ce2453eaaedfccf78c36fca5b590b5b#commitcomment-32742987 the replace of {UrlResolver} were removed.

So when building the url we got "Https://mysite.se/modules/Gosso.EPiServerAddOn.DownloadIfMissingFileBlob/{UrlResolver}?[guid].

After seeing this we added UrlResolverUrl to our configs but still could not get it to work. After changing the url to lower case it magically started to work for us.