### PR TITLE
UrlResolverUrl to lower case

### DIFF
--- a/Project/DownloadIfMissingFileProvider.cs
+++ b/Project/DownloadIfMissingFileProvider.cs
@@ -154,10 +154,10 @@ namespace Gosso.EPiServerAddOn.DownloadIfMissingFileBlob
 
             if (config.Get("UrlResolverUrl") != null)
             {
-                UrlResolverUrl = config.Get("UrlResolverUrl");
+                UrlResolverUrl = config.Get("UrlResolverUrl").ToLower();
             }
             else
-                UrlResolverUrl = DefaultUrl;
+                UrlResolverUrl = DefaultUrl.ToLower();
 
             if (Activated)
             {


### PR DESCRIPTION
So after some more testing I realized that the issues probably is within our server settings or something. Making it work with only lowercase in urlResolverUrl.

The route register can register with capitalized letter and still work, but when executing _httpClient.GetAsync it does not work unless I have lower case.

You said earlier to maybe change this to lowercase for next version, so here is just a snippet of what made it work for me, but since i have added `UrlResolverUrl="modules/gosso.episerveraddon.downloadifmissingfileblob/urlresolver.ashx"` to my web.config it still works for me now in our local and test environment.

> **Servers Handle Capitalization Differently**
If your website is on a Windows server, then www.example.com/about will be handled exactly the same as www.example.com/About.  The Windows server is case insensitive.  If your website is hosted on Linux, then those two addresses will be seen as two different pages.  That means that one will return the correct page, and the other will return a dead 404 page not found.  So, if you originally host on a Windows server and move to a Linux server, you could be in for mass confusion and a lot of page errors for your users.  Further, if you use capital letters for your URLs on a Linux server, users will get a dead page if they attempt to use all lowercase letters to access a page.

(https://wiredimpact.com/blog/never-use-capital-letters-urls/)